### PR TITLE
Handle PPh23 in totals and journal credits

### DIFF
--- a/application/modules/penerimaan_uang/controllers/Penerimaan_uang.php
+++ b/application/modules/penerimaan_uang/controllers/Penerimaan_uang.php
@@ -184,8 +184,8 @@ class Penerimaan_uang extends Admin_Controller
             $hasil .= '</td>';
             $hasil .= '</tr>';
 
-            // $total_piutang += ($pph23_dipotong == 'N') ? $get_inv['tagihan_ppn_jurnal'] : $get_inv['total_akhir_jurnal'];
-            $total_piutang += $get_inv['total_akhir_jurnal'];
+            $total_piutang += ($pph23_dipotong == 'N') ? $get_inv['tagihan_ppn_jurnal'] : $get_inv['total_akhir_jurnal'];
+            // $total_piutang += $get_inv['total_akhir_jurnal'];
             $total_piutang_dagang += $saldo_piutang;
 
             if ($no == 1) {

--- a/application/modules/penerimaan_uang/views/process.php
+++ b/application/modules/penerimaan_uang/views/process.php
@@ -316,12 +316,20 @@
 
             $('input[name="sisa_piutang_' + i + '"]').autoNumeric('set', sisa_piutang);
 
-            var coa_jurnal = ['1102-01-01', '7201-01-04', '1106-01-02'];
+            var coa_jurnal = ['1102-01-01', '7201-01-04', '1106-01-02', '1106-01-05'];
             $.each(coa_jurnal, function(index, value) {
                 index = index + 1;
                 if (value == '1102-01-01') {
-                    var resp_piutang = number_format(piutang_dagang);
-                    resp_piutang += '<input type="hidden" name="kredit_' + value + '_' + i + '" value="' + piutang_dagang + '">';
+                    var kredit_piutang_dagang;
+                    if (pph23_dipotong == 'Y') {
+                        // Dipotong PPh: kredit piutang dagang = Tagihan + PPN (full)
+                        kredit_piutang_dagang = piutang;
+                    } else {
+                        // Tidak dipotong: kredit piutang dagang = Tagihan + PPN - PPh (net)
+                        kredit_piutang_dagang = piutang_dagang;
+                    }
+                    var resp_piutang = number_format(kredit_piutang_dagang);
+                    resp_piutang += '<input type="hidden" name="kredit_' + value + '_' + i + '" value="' + kredit_piutang_dagang + '">';
 
                     $('.td_kredit_' + value + '_' + i).html(resp_piutang);
                 }


### PR DESCRIPTION
Adjust PPh23 withholding handling for receivables and journal lines. In the controller, total_piutang now uses tagihan_ppn_jurnal when PPh23 is not withheld (pph23_dipotong == 'N'), otherwise it uses total_akhir_jurnal. In the view, added COA '1106-01-05' and updated the credit calculation for '1102-01-01' to choose between full piutang (when PPh23 is withheld) and net piutang_dagang (when it's not), and emit the appropriate hidden kredit_* input. This fixes incorrect totals and journal credit amounts when PPh23 withholding applies.