### PR TITLE
Add no_pr to search filters

### DIFF
--- a/application/modules/non_rutin/models/Non_rutin_model.php
+++ b/application/modules/non_rutin/models/Non_rutin_model.php
@@ -626,6 +626,7 @@ class Non_rutin_model extends BF_Model
             a.close_pr IS NULL
             AND (
 				a.no_pengajuan LIKE '%" . $this->db->escape_like_str($like_value) . "%'
+                OR a.no_pr LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR a.tanggal LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR a.no_pr LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 	        )
@@ -678,6 +679,7 @@ class Non_rutin_model extends BF_Model
             a.close_pr IS NULL
             AND (
 				a.no_pengajuan LIKE '%" . $this->db->escape_like_str($like_value) . "%'
+                OR a.no_pr LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR a.tanggal LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR a.no_pr LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 	        )
@@ -731,6 +733,7 @@ class Non_rutin_model extends BF_Model
             a.close_pr IS NULL
             AND (
 				a.no_pengajuan LIKE '%" . $this->db->escape_like_str($like_value) . "%'
+                OR a.no_pr LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR a.tanggal LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR a.no_pr LIKE '%" . $this->db->escape_like_str($like_value) . "%'
 				OR b.nama LIKE '%" . $this->db->escape_like_str($like_value) . "%'


### PR DESCRIPTION
Include a.no_pr LIKE ... conditions in the query WHERE clauses of application/modules/non_rutin/models/Non_rutin_model.php so searches will match PR numbers. The new OR a.no_pr checks were added in three search blocks (with a.close_pr IS NULL) alongside existing no_pengajuan, tanggal and nama filters to allow filtering by PR number.