### PR TITLE
Remove duplicate DB from() call in Invoicing

### DIFF
--- a/application/modules/invoicing/controllers/Invoicing.php
+++ b/application/modules/invoicing/controllers/Invoicing.php
@@ -809,7 +809,6 @@ class Invoicing extends Admin_Controller
 
         $this->db->select('a.*');
         $this->db->from(DBCNL . '.kons_tr_penawaran_non_konsultasi a');
-        $this->db->from(DBCNL . '.kons_tr_penawaran_non_konsultasi a');
         $this->db->where('a.id_penawaran', $get_invoicing->id_penawaran);
         $get_penawaran = $this->db->get()->row();
 


### PR DESCRIPTION
Remove a duplicated $this->db->from() call in application/modules/invoicing/controllers/Invoicing.php when querying kons_tr_penawaran_non_konsultasi. This avoids a redundant table selection in the query and potential SQL issues; the query still selects the row by id_penawaran as intended.