### PR TITLE
Make invoice date editable in forms

### DIFF
--- a/application/modules/invoicing/views/add_invoice_non_konsultasi.php
+++ b/application/modules/invoicing/views/add_invoice_non_konsultasi.php
@@ -25,7 +25,7 @@
                         </td>
                         <th width="13%">Tanggal Invoice</th>
                         <td width="12%">
-                            <input type="date" name="tanggal_invoice" id="" class="form-control form-control-sm" placeholder="Tanggal Invoice" value="<?= date('Y-m-d') ?>" readonly>
+                            <input type="date" name="tanggal_invoice" id="" class="form-control form-control-sm" placeholder="Tanggal Invoice" value="<?= date('Y-m-d') ?>">
                         </td>
                     </tr>
                     <tr>

--- a/application/modules/invoicing/views/edit_invoice_non_konsultasi.php
+++ b/application/modules/invoicing/views/edit_invoice_non_konsultasi.php
@@ -25,7 +25,7 @@
                         </td>
                         <th width="13%">Tanggal Invoice</th>
                         <td width="12%">
-                            <input type="date" name="tanggal_invoice" id="" class="form-control form-control-sm" placeholder="Tanggal Invoice" value="<?= htmlspecialchars($data_invoicing->tanggal_invoice, ENT_QUOTES, 'UTF-8') ?>" readonly>
+                            <input type="date" name="tanggal_invoice" id="" class="form-control form-control-sm" placeholder="Tanggal Invoice" value="<?= htmlspecialchars($data_invoicing->tanggal_invoice, ENT_QUOTES, 'UTF-8') ?>">
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Remove readonly attribute from the tanggal_invoice date input in add and edit non_konsultasi invoice views so users can modify the invoice date. Updated files: application/modules/invoicing/views/add_invoice_non_konsultasi.php and application/modules/invoicing/views/edit_invoice_non_konsultasi.php.