### PR TITLE
Enforce tagih_mundur date logic and update UI

### DIFF
--- a/application/modules/actual_plan_tagih/controllers/Actual_plan_tagih.php
+++ b/application/modules/actual_plan_tagih/controllers/Actual_plan_tagih.php
@@ -170,17 +170,14 @@ class Actual_plan_tagih extends Admin_Controller
             } else {
                 $id = $this->Actual_plan_tagih_model->generate_id();
 
-                if (!empty($post['tanggal_actual'])) {
-                    $tanggal_actual = $post['tanggal_actual'];
+                if ($post['tagih_mundur'] == '1') {
+                    $tanggal_actual = $post['tgl_plan_tagih'];
                 } else {
-                    if (!empty($post['tgl_actual_tagih_last'])) {
-                        $tanggal_actual = $post['tgl_actual_tagih_last'];
-                    } else {
-                        $tanggal_actual = $post['tgl_plan_tagih'];
+                    if (empty($post['tanggal_actual'])) {
+                        throw new Exception('Mohon pilih tanggal rencana penagihan untuk status "Mundur"!');
                     }
+                    $tanggal_actual = $post['tanggal_actual'];
                 }
-
-                $tanggal_actual = (!empty($post['tanggal_actual'])) ? $post['tanggal_actual'] : $post['tgl_plan_tagih'];
 
                 $arr_insert = [
                     'id' => $id,

--- a/application/modules/actual_plan_tagih/views/form_actual_plan_tagih.php
+++ b/application/modules/actual_plan_tagih/views/form_actual_plan_tagih.php
@@ -21,21 +21,22 @@
                 <input type="hidden" name="persen_payment" value="<?= $data_plan_tagih_detail->persen_payment ?>">
                 <input type="hidden" name="nominal_payment" value="<?= $data_plan_tagih_detail->nominal_payment ?>">
                 <input type="hidden" name="desc_payment" value="<?= $data_plan_tagih_detail->desc_payment ?>">
-                <input type="hidden" name="tgl_plan_tagih" value="<?= $data_plan_tagih_detail->tgl_plan_tagih ?>">
+                <input type="hidden" name="tgl_plan_tagih" id="tgl_plan_tagih" value="<?= $data_plan_tagih_detail->tgl_plan_tagih ?>">
+                <input type="hidden" name="status_terakhir" id="status_terakhir" value="<?= $data_plan_tagih_detail->status_terakhir ?>">
                 <input type="hidden" name="urutan" value="<?= $data_plan_tagih_detail->urutan ?>">
                 <input type="hidden" name="macet" value="<?= $macet ?>">
                 <input type="hidden" name="tgl_actual_tagih_last" value="<?= $tgl_actual_tagih_last ?>">
             </td>
             <td class="text-left"><?= $data_plan_tagih_detail->desc_payment ?></td>
             <td>
-                <select name="tagih_mundur" id="" class="form-control form-control-sm">
+                <select name="tagih_mundur" id="tagih_mundur" class="form-control form-control-sm">
                     <option value="1">Tagih</option>
                     <option value="2">Mundur</option>
                     <option value="3">Tagihan Macet</option>
                 </select>
             </td>
             <td>
-                <input type="date" name="tanggal_actual" id="" class="form-control form-control-sm" class="text-center">
+                <input type="date" name="tanggal_actual" id="tanggal_actual" class="form-control form-control-sm text-center" disabled>
             </td>
             <td>
                 <textarea name="alasan_mundur" id="" class="form-control form-control-sm" readonly></textarea>
@@ -55,3 +56,19 @@
         <input type="file" name="upload_laporan_progress" id="upload_laporan_progress" class="form-control form-control-sm">
     </div>
 </div>
+
+<script>
+$(document).ready(function() {
+    var status_terakhir = $('input[name="status_terakhir"]').val();
+    var tgl_plan_tagih = $('input[name="tgl_plan_tagih"]').val();
+
+    if (status_terakhir == '2') {
+        $('input[name="tanggal_actual"]').prop('disabled', false);
+        $('textarea[name="alasan_mundur"]').attr('readonly', false);
+        $('input[name="upload_surat_mundur"]').prop('disabled', false);
+        $('select[name="tagih_mundur"]').val('2');
+    } else {
+        $('input[name="tanggal_actual"]').val(tgl_plan_tagih);
+    }
+});
+</script>

--- a/application/modules/actual_plan_tagih/views/index.php
+++ b/application/modules/actual_plan_tagih/views/index.php
@@ -214,14 +214,37 @@ $ENABLE_DELETE  = has_permission('Actual_Plan_Tagih.Delete');
 
     $(document).on('change', 'select[name="tagih_mundur"]', function() {
         var tagih_mundur = $(this).val();
+        var tgl_plan_tagih = $('input[name="tgl_plan_tagih"]').val();
+        var current_tanggal_actual = $('input[name="tanggal_actual"]').val();
 
         if (tagih_mundur == '1' || tagih_mundur == '3') {
-            // $('input[name="tanggal_actual"]').attr('readonly', true);
+            $('input[name="tanggal_actual"]').prop('disabled', true);
+            $('input[name="tanggal_actual"]').val(tgl_plan_tagih);
             $('textarea[name="alasan_mundur"]').attr('readonly', true);
             $('input[name="upload_surat_mundur"]').prop('disabled', true);
+
+            if (tagih_mundur == '1') {
+                Swal.fire({
+                    icon: 'info',
+                    title: 'Info',
+                    text: 'Anda memilih "Tagih". Tanggal actual akan menggunakan tgl_plan_tagih.',
+                    confirmButtonColor: '#3085d6',
+                    confirmButtonText: 'OK'
+                });
+            }
         }
         if (tagih_mundur == '2') {
-            // $('input[name="tanggal_actual"]').attr('readonly', false);
+            if (current_tanggal_actual && current_tanggal_actual !== tgl_plan_tagih) {
+                Swal.fire({
+                    icon: 'warning',
+                    title: 'Warning',
+                    text: 'Akan switch ke "Mundur". Tanggal yang Anda input sebelumnya akan di-reset. Mohon isi tanggal baru.',
+                    confirmButtonColor: '#f0ad4e',
+                    confirmButtonText: 'OK'
+                });
+            }
+            $('input[name="tanggal_actual"]').prop('disabled', false);
+            $('input[name="tanggal_actual"]').val('');
             $('textarea[name="alasan_mundur"]').attr('readonly', false);
             $('input[name="upload_surat_mundur"]').prop('disabled', false);
         }


### PR DESCRIPTION
Controller: enforce date selection based on tagih_mundur — if tagih_mundur == '1' use tgl_plan_tagih, otherwise require tanggal_actual and throw an exception when missing; removed previous fallback logic.

Views: add IDs and hidden status_terakhir/tgl_plan_tagih fields, default-disable the tanggal_actual input and make alasan_mundur readonly. Add client-side script to enable/disable fields based on status_terakhir and to prefill tgl_plan_tagih when appropriate.

Index JS: improve tagih_mundur change handling — disable/enable tanggal_actual and related inputs, reset tanggal_actual when switching to "Mundur", and show Swal notifications informing users about automatic resets or info when selecting "Tagih".