### PR TITLE
Use submitted tgl_plan_tagih value

### DIFF
--- a/application/modules/actual_plan_tagih/controllers/Actual_plan_tagih.php
+++ b/application/modules/actual_plan_tagih/controllers/Actual_plan_tagih.php
@@ -189,7 +189,7 @@ class Actual_plan_tagih extends Admin_Controller
                     'persen_payment' => $post['persen_payment'],
                     'nominal_payment' => $post['nominal_payment'],
                     'desc_payment' => $post['desc_payment'],
-                    'tgl_plan_tagih' => $tanggal_actual,
+                    'tgl_plan_tagih' => $post['tgl_plan_tagih'],
                     'urutan' => $post['urutan'],
                     'tanggal_actual_plan_tagih' => $tanggal_actual,
                     'tagih_mundur' => $post['tagih_mundur'],


### PR DESCRIPTION
Changed assignment of tgl_plan_tagih in Actual_plan_tagih controller to use the posted value ($post['tgl_plan_tagih']) instead of the computed $tanggal_actual. This preserves the user-submitted plan date when saving records rather than overwriting it with the computed actual date.