### PR TITLE
Fix PPh23 check and journal credit assignment

### DIFF
--- a/application/modules/penerimaan_uang/controllers/Penerimaan_uang.php
+++ b/application/modules/penerimaan_uang/controllers/Penerimaan_uang.php
@@ -321,7 +321,7 @@ class Penerimaan_uang extends Admin_Controller
                     $value_debit = 0;
                     $value_kredit = 0;
 
-                    if ($post['pph23_dipotong'] == '2' && $item_coa_jurnal['no_perkiraan'] == $coa_pph) {
+                    if ($post['pph23_dipotong'] == 'N' && $item_coa_jurnal['no_perkiraan'] == $coa_pph) {
                         $this->db->select('a.pph_jurnal as ttl_kredit');
                         $this->db->from('tr_invoicing a');
                         $this->db->where('a.id', $item);
@@ -330,7 +330,7 @@ class Penerimaan_uang extends Admin_Controller
                         $value_kredit = $get_kredit['ttl_kredit'];
                     }
                     if ($item_coa_jurnal['no_perkiraan'] == '1102-01-01') {
-                        $value_debit = $get_inv['total_akhir_jurnal'];
+                        $value_kredit = $get_inv['total_akhir_jurnal'];
                     }
 
                     $hasil_jurnal .= '<tr>';


### PR DESCRIPTION
Adjust PPh23 handling and correct journal amount side in Penerimaan_uang controller. The condition checking post['pph23_dipotong'] was changed from '2' to 'N' so the PPh lookup runs for the intended flag value, and the account '1102-01-01' now assigns its amount to value_kredit (credit) instead of value_debit, fixing an incorrect debit/credit mapping in generated journal rows.